### PR TITLE
Hot fix start android emulation path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,7 @@ Variable path -> path\to\androidSDK
 ```
 #### Mac OSX:
 **1a.** If the machine does not have a .bash_profile, open a terminal and proceed with the following: 
-`$ touch ~./bash_profile`
+`$ touch ~/.bash_profile`
 
 **1b.** Open the bash profile:
 `$ open ~/.bash_profile

--- a/src/test/java/setup/DriverFactory.java
+++ b/src/test/java/setup/DriverFactory.java
@@ -125,8 +125,7 @@ public class DriverFactory {
       if (isWindows) {
         Runtime.getRuntime().exec(Paths.get(scriptsPath, "startAndroidEmulator.bat").toString());
       } else {
-        Runtime.getRuntime().exec("cd $ANDROID_HOME/emulator");
-        Runtime.getRuntime().exec("emulator -avd emulator-5554");
+        Runtime.getRuntime().exec(Paths.get(scriptsPath, "startAndroidEmulator.sh").toString());
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/test/java/setup/DriverFactory.java
+++ b/src/test/java/setup/DriverFactory.java
@@ -118,8 +118,8 @@ public class DriverFactory {
   /** Start Android Emulator */
   private void startAndroidEmulation() {
 
-    boolean isWindows = Config.OS.equalsIgnoreCase("windows");
-    String scriptsPath = Paths.get(WORKSPACE, "src", "resources", "scripts").toString();
+    boolean isWindows = Config.OS.contains("windows");
+    String scriptsPath = Paths.get(WORKSPACE, "src", "test", "resources", "scripts").toString();
 
     try {
       if (isWindows) {


### PR DESCRIPTION
The path to the android emulation scripts were incorrect. This pull request addresses the issue by adding in a missing parameter in the path.